### PR TITLE
Flush any pending buffers on close()

### DIFF
--- a/src/jaegertracing/Tracer.h
+++ b/src/jaegertracing/Tracer.h
@@ -102,7 +102,7 @@ class Tracer : public opentracing::Tracer,
             serviceName, sampler, reporter, logger, metrics, options));
     }
 
-    ~Tracer() { Close(); }
+    ~Tracer() { close(); }
 
     std::unique_ptr<opentracing::Span>
     StartSpanWithOptions(string_view operationName,
@@ -182,6 +182,12 @@ class Tracer : public opentracing::Tracer,
 
     void Close() noexcept override
     {
+        flush();
+        close();
+    }
+
+    void close() noexcept
+    {
         try {
             _reporter->close();
             _sampler->close();
@@ -192,7 +198,10 @@ class Tracer : public opentracing::Tracer,
         }
     }
 
-    void close() noexcept { Close(); }
+    void flush()
+    {
+        _reporter->flush();
+    }
 
     const std::string& serviceName() const { return _serviceName; }
 

--- a/src/jaegertracing/reporters/RemoteReporter.h
+++ b/src/jaegertracing/reporters/RemoteReporter.h
@@ -48,12 +48,14 @@ class RemoteReporter : public Reporter {
 
     void close() override;
 
+    void flush() override;
+
   private:
     void sweepQueue();
 
     void sendSpan(const Span& span);
 
-    void flush();
+    void async_flush();
 
     bool bufferFlushIntervalExpired() const
     {
@@ -70,6 +72,7 @@ class RemoteReporter : public Reporter {
     bool _running;
     Clock::time_point _lastFlush;
     std::condition_variable _cv;
+    std::condition_variable _cv_flush;
     std::mutex _mutex;
     std::thread _thread;
 };

--- a/src/jaegertracing/reporters/Reporter.h
+++ b/src/jaegertracing/reporters/Reporter.h
@@ -30,6 +30,8 @@ class Reporter {
     virtual void report(const Span& span) = 0;
 
     virtual void close() = 0;
+
+    virtual void flush() {};
 };
 
 }  // namespace reporters


### PR DESCRIPTION
The RemoteReporter buffers spans, but didn't flush them on close.
So any spans Finish()ed between the last flush interval and the
Close() of the Tracer would be lost.

Fixes #52

Signed-off-by: Craig Ringer <craig@2ndquadrant.com>