### PR TITLE
Record logs passed with Span::FinishWithOptions

### DIFF
--- a/src/jaegertracing/LogRecord.h
+++ b/src/jaegertracing/LogRecord.h
@@ -25,6 +25,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <opentracing/span.h>
+
 namespace jaegertracing {
 
 class LogRecord {
@@ -42,6 +44,12 @@ class LogRecord {
               FieldIterator last)
         : _timestamp(timestamp)
         , _fields(first, last)
+    {
+    }
+
+    LogRecord(const opentracing::LogRecord & other)
+        : _timestamp(other.timestamp),
+          _fields(other.fields.begin(), other.fields.end())
     {
     }
 

--- a/src/jaegertracing/Span.cpp
+++ b/src/jaegertracing/Span.cpp
@@ -97,6 +97,10 @@ void Span::FinishWithOptions(
         }
         _duration = finishTimeSteady - _startTimeSteady;
         tracer = _tracer;
+
+        std::copy(finishSpanOptions.log_records.begin(),
+                  finishSpanOptions.log_records.end(),
+                  std::back_inserter(_logs));
     }
 
     // Call `reportSpan` even for non-sampled traces.

--- a/src/jaegertracing/Tag.h
+++ b/src/jaegertracing/Tag.h
@@ -38,6 +38,13 @@ class Tag {
     {
     }
 
+    template <typename ValueArg>
+    Tag(const std::pair<std::string,ValueArg> & tag_pair)
+        : _key(tag_pair.first)
+        , _value(tag_pair.second)
+    {
+    }
+
     bool operator==(const Tag& rhs) const
     {
         return _key == rhs._key && _value == rhs._value;

--- a/src/jaegertracing/TracerTest.cpp
+++ b/src/jaegertracing/TracerTest.cpp
@@ -180,7 +180,12 @@ TEST(Tracer, testTracer)
     ASSERT_EQ("test-baggage-item-value",
               span->BaggageItem("test-baggage-item-key"));
     span->Log({ { "log-bool", true } });
-    span->Finish();
+    opentracing::FinishSpanOptions foptions;
+    opentracing::LogRecord lr{};
+    lr.fields = { {"options-log", "yep"} };
+    foptions.log_records.push_back(std::move(lr));
+    lr.timestamp = opentracing::SystemClock::now();
+    span->FinishWithOptions(foptions);
     ASSERT_GE(Span::SteadyClock::now(),
               span->startTimeSteady() + span->duration());
     span->SetOperationName("test-set-operation-after-finish");


### PR DESCRIPTION
Jaeger cpp-client was dropping logs included in a FinishSpanOptions
silently on the floor. Append them to the log buffer during FinishWithOptions instead.

Fixes #57

Signed-off-by: Craig Ringer <craig@2ndquadrant.com>