### PR TITLE
Remote reporter flush fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,6 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true
-BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -50,7 +49,6 @@ IncludeCategories:
     Priority:        3
   - Regex:           '.*'
     Priority:        1
-IncludeIsMainRegex: '$'
 IndentCaseLabels: false
 IndentWidth:     4
 IndentWrappedFunctionNames: false
@@ -72,7 +70,6 @@ PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    true
 SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false

--- a/src/jaegertracing/reporters/CompositeReporter.h
+++ b/src/jaegertracing/reporters/CompositeReporter.h
@@ -41,7 +41,7 @@ class CompositeReporter : public Reporter {
 
     ~CompositeReporter() { close(); }
 
-    void report(const Span& span) override
+    void report(const Span& span) noexcept override
     {
         std::for_each(
             std::begin(_reporters),
@@ -49,7 +49,7 @@ class CompositeReporter : public Reporter {
             [&span](const ReporterPtr& reporter) { reporter->report(span); });
     }
 
-    void close() override
+    void close() noexcept override
     {
         std::for_each(std::begin(_reporters),
                       std::end(_reporters),

--- a/src/jaegertracing/reporters/InMemoryReporter.h
+++ b/src/jaegertracing/reporters/InMemoryReporter.h
@@ -36,27 +36,27 @@ class InMemoryReporter : public Reporter {
         _spans.reserve(kInitialCapacity);
     }
 
-    void report(const Span& span) override
+    void report(const Span& span) noexcept override
     {
         std::lock_guard<std::mutex> lock(_mutex);
         _spans.push_back(span);
     }
 
-    void close() override {}
+    void close() noexcept override {}
 
-    int spansSubmitted() const
+    int spansSubmitted() const noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
         return _spans.size();
     }
 
-    std::vector<Span> spans() const
+    std::vector<Span> spans() const noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
         return _spans;
     }
 
-    void reset()
+    void reset() noexcept
     {
         std::lock_guard<std::mutex> lock(_mutex);
         _spans.clear();

--- a/src/jaegertracing/reporters/LoggingReporter.cpp
+++ b/src/jaegertracing/reporters/LoggingReporter.cpp
@@ -22,7 +22,7 @@
 namespace jaegertracing {
 namespace reporters {
 
-void LoggingReporter::report(const Span& span)
+void LoggingReporter::report(const Span& span) noexcept
 {
     std::ostringstream oss;
     oss << "Reporting span " << span;

--- a/src/jaegertracing/reporters/LoggingReporter.h
+++ b/src/jaegertracing/reporters/LoggingReporter.h
@@ -30,9 +30,9 @@ class LoggingReporter : public Reporter {
     {
     }
 
-    void report(const Span& span) override;
+    void report(const Span& span) noexcept override;
 
-    void close() override {}
+    void close() noexcept override {}
 
   private:
     logging::Logger& _logger;

--- a/src/jaegertracing/reporters/NullReporter.h
+++ b/src/jaegertracing/reporters/NullReporter.h
@@ -28,9 +28,9 @@ namespace reporters {
 
 class NullReporter : public Reporter {
   public:
-    void report(const Span&) override {}
+    void report(const Span&) noexcept override {}
 
-    void close() override {}
+    void close() noexcept override {}
 };
 
 }  // namespace reporters

--- a/src/jaegertracing/reporters/RemoteReporter.cpp
+++ b/src/jaegertracing/reporters/RemoteReporter.cpp
@@ -69,10 +69,10 @@ void RemoteReporter::close() noexcept
                 return;
             }
             _running = false;
-            flush();
         }
         _cv.notify_one();
         _thread.join();
+        flush();
     } catch (...) {
         utils::ErrorUtil::logError(_logger, "Failed in Reporter::close");
     }

--- a/src/jaegertracing/reporters/RemoteReporter.h
+++ b/src/jaegertracing/reporters/RemoteReporter.h
@@ -44,16 +44,16 @@ class RemoteReporter : public Reporter {
 
     ~RemoteReporter() { close(); }
 
-    void report(const Span& span) override;
+    void report(const Span& span) noexcept override;
 
-    void close() override;
+    void close() noexcept override;
 
   private:
-    void sweepQueue();
+    void sweepQueue() noexcept;
 
-    void sendSpan(const Span& span);
+    void sendSpan(const Span& span) noexcept;
 
-    void flush();
+    void flush() noexcept;
 
     bool bufferFlushIntervalExpired() const
     {

--- a/src/jaegertracing/reporters/Reporter.h
+++ b/src/jaegertracing/reporters/Reporter.h
@@ -27,9 +27,9 @@ class Reporter {
   public:
     virtual ~Reporter() = default;
 
-    virtual void report(const Span& span) = 0;
+    virtual void report(const Span& span) noexcept = 0;
 
-    virtual void close() = 0;
+    virtual void close() noexcept = 0;
 };
 
 }  // namespace reporters


### PR DESCRIPTION
Guarantee a flush occurs on destruction of `RemoteReporter`. Add more `noexcept` specifiers for reporter methods.