### PR TITLE
Fix dynamic loading test coverage.

### DIFF
--- a/src/jaegertracing/TracerFactoryTest.cpp
+++ b/src/jaegertracing/TracerFactoryTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "jaegertracing/Constants.h"
 #include "jaegertracing/TracerFactory.h"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Signed-off-by: Ryan Burn <ryan.burn@gmail.com>

Sorry. Minor follow up to #64  to fix the test coverage. The TraceFactory tests was missing "#include "jaegertracing/Constants.h" which caused some of them not to run.